### PR TITLE
make a join generic function for all types

### DIFF
--- a/src/internal/util.js
+++ b/src/internal/util.js
@@ -1,6 +1,5 @@
 var _equals = require('ramda/src/equals');
 
-
 module.exports = {
 
   baseMap: function(f) {
@@ -54,6 +53,14 @@ module.exports = {
         return Type.of(f(a));
       });
     };
-  }
+  },
 
+  getJoinForTypes : function(m) {
+  return function() {
+    return this.value instanceof m
+      ? this.value.join()
+      : m.of(this.value);
+  }
+}
+  
 };


### PR DESCRIPTION
I think it would be nice for the types to have a join method, here a simple implementation.

```js
getJoinForTypes : function(m) {
  return function() {
    return this.value instanceof m
      ? this.value.join()
      : m.of(this.value);
  }
}

//the usage
Maybe.prototype.join = getJoinForTypes(Maybe);
IO.prototype.join = getJoinForTypes(IO)
//etc...
```